### PR TITLE
feat: add support to open Amplify app stack with browser

### DIFF
--- a/.changeset/dull-toes-film.md
+++ b/.changeset/dull-toes-film.md
@@ -1,0 +1,5 @@
+---
+"amplify-backend-vscode": minor
+---
+
+feat: add support to open Amplify app stack with browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/vscode": "^1.90.0",
         "@vscode/test-cli": "^0.0.12",
         "@vscode/test-electron": "^2.4.0",
+        "aws-sdk-client-mock": "^4.1.0",
         "cross-env": "^10.0.0",
         "esbuild": "^0.27.0",
         "eslint": "^9.9.0",
@@ -91,12 +92,14 @@
     "node_modules/@aws-cdk/asset-awscli-v1": {
       "version": "2.2.233",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.233.tgz",
-      "integrity": "sha512-OH5ZN1F/0wwOUwzVUSvE0/syUOi44H9the6IG16anlSptfeQ1fvduJazZAKRuJLtautPbiqxllyOrtWh6LhX8A=="
+      "integrity": "sha512-OH5ZN1F/0wwOUwzVUSvE0/syUOi44H9the6IG16anlSptfeQ1fvduJazZAKRuJLtautPbiqxllyOrtWh6LhX8A==",
+      "peer": true
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
-      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A=="
+      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
+      "peer": true
     },
     "node_modules/@aws-cdk/aws-service-spec": {
       "version": "0.1.110",
@@ -1555,7 +1558,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.935.0.tgz",
       "integrity": "sha512-6mfYqbIb0hiuX2omcqcntF1obVTKmqb4ONDiAHaOY27azrzgQOUHvqYoru3GkZk2qPXmxcyTWjoyWovSo6xv2A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -10220,7 +10222,6 @@
       "version": "3.775.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.775.0.tgz",
       "integrity": "sha512-ZoGKwa4C9fC9Av6bdfqcW6Ix5ot05F/S4VxWR2nHuMv7hzfmAjTOcUiWT7UR4hM/U0whf84VhDtXN/DWAk52KA==",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
@@ -11922,7 +11923,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -12010,6 +12010,54 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.3.tgz",
+      "integrity": "sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "dev": true,
+      "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.5",
@@ -12797,10 +12845,26 @@
       "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/sinon": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
+      "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
@@ -12860,7 +12924,6 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -13198,7 +13261,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -13500,6 +13562,7 @@
         "jsonschema",
         "semver"
       ],
+      "peer": true,
       "dependencies": {
         "jsonschema": "~1.4.1",
         "semver": "^7.7.1"
@@ -13512,6 +13575,7 @@
       "version": "1.4.1",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -13520,6 +13584,7 @@
       "version": "7.7.1",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -13530,12 +13595,14 @@
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",
       "inBundle": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
       "version": "8.17.1",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -13551,6 +13618,7 @@
       "version": "5.0.1",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -13559,6 +13627,7 @@
       "version": "4.3.0",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -13573,6 +13642,7 @@
       "version": "2.0.0",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -13580,12 +13650,14 @@
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
       "version": "1.0.2",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
       "version": "1.1.11",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -13595,6 +13667,7 @@
       "version": "1.6.3",
       "inBundle": true,
       "license": "(MIT OR GPL-3.0-or-later)",
+      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -13603,6 +13676,7 @@
       "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -13613,22 +13687,26 @@
     "node_modules/aws-cdk-lib/node_modules/color-name": {
       "version": "1.1.4",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/concat-map": {
       "version": "0.0.1",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
       "version": "8.0.0",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
       "version": "3.0.6",
@@ -13643,12 +13721,14 @@
         }
       ],
       "inBundle": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
       "version": "11.3.0",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -13661,12 +13741,14 @@
     "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
       "version": "4.2.11",
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
       "version": "5.3.2",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -13675,6 +13757,7 @@
       "version": "3.0.0",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -13682,12 +13765,14 @@
     "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.1.0",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -13699,6 +13784,7 @@
       "version": "1.5.0",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -13706,12 +13792,14 @@
     "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
       "version": "4.4.2",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/mime-db": {
       "version": "1.52.0",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -13720,6 +13808,7 @@
       "version": "2.1.35",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -13731,6 +13820,7 @@
       "version": "3.1.2",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -13742,6 +13832,7 @@
       "version": "2.3.1",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -13750,6 +13841,7 @@
       "version": "2.0.2",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13758,6 +13850,7 @@
       "version": "7.7.1",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -13769,6 +13862,7 @@
       "version": "4.0.0",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -13785,6 +13879,7 @@
       "version": "4.2.3",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -13798,6 +13893,7 @@
       "version": "6.0.1",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -13809,6 +13905,7 @@
       "version": "6.9.0",
       "inBundle": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.1",
         "lodash.truncate": "^4.4.2",
@@ -13824,6 +13921,7 @@
       "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -13832,8 +13930,21 @@
       "version": "1.10.2",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/aws-sdk-client-mock": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-4.1.0.tgz",
+      "integrity": "sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinon": "^17.0.3",
+        "sinon": "^18.0.1",
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/b4a": {
@@ -14465,7 +14576,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -15594,6 +15704,13 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -16098,6 +16215,30 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/nise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
+      "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.1",
+        "@sinonjs/text-encoding": "^0.7.3",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.1.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -16540,6 +16681,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -16962,6 +17114,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sinon": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
+      "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "11.2.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.2.0",
+        "nise": "^6.0.0",
+        "supports-color": "^7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/slash": {
@@ -17448,13 +17642,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
     "@types/vscode": "^1.90.0",
     "@vscode/test-cli": "^0.0.12",
     "@vscode/test-electron": "^2.4.0",
+    "aws-sdk-client-mock": "^4.1.0",
     "cross-env": "^10.0.0",
     "esbuild": "^0.27.0",
     "eslint": "^9.9.0",

--- a/src/client/provider.ts
+++ b/src/client/provider.ts
@@ -1,0 +1,19 @@
+import { CloudFormationClient } from "@aws-sdk/client-cloudformation";
+import Auth from "../auth/credentials";
+
+export interface AWSClientProvider {
+  getCloudFormationClient(): Promise<CloudFormationClient>;
+}
+
+export function getAWSClientProvider(): AWSClientProvider {
+  return {
+    async getCloudFormationClient() {
+      const profile = await Auth.instance.getProfile();
+      const region = await Auth.instance.getRegion(profile);
+      return new CloudFormationClient({
+        profile,
+        region,
+      });
+    },
+  };
+}

--- a/src/explorer/amplify-backend-resource-tree-node.ts
+++ b/src/explorer/amplify-backend-resource-tree-node.ts
@@ -10,7 +10,10 @@ export class AmplifyBackendResourceTreeNode extends AmplifyBackendBaseNode {
     public readonly label: string,
     public readonly cloudformationType: string,
     public readonly backendIdentifier: BackendIdentifier,
-    public readonly resource?: StackResourceSummary,
+    public readonly resource?: Pick<
+        StackResourceSummary,
+        "ResourceType" | "PhysicalResourceId"
+      >,
     public readonly region?: string,
   ) {
     super(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,8 +8,9 @@ import { addSecretCommand } from "./secrets/add-secret-command";
 import { DefaultResourceFilterProvider } from "./explorer/resource-filter";
 import { openConsoleCommand } from "./explorer/commands/open-console-command";
 import { copyUrlCommand } from "./explorer/commands/copy-url-command";
+import { getAWSClientProvider } from "./client/provider";
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       "amplify-backend-explorer.openConsole",
@@ -33,9 +34,11 @@ export function activate(context: vscode.ExtensionContext) {
     context.workspaceState
   );
 
+  const awsClientProvider = await getAWSClientProvider();
   const amplifyBackendTreeDataProvider = new AmplifyBackendTreeDataProvider(
     rootPath || "",
-    resourceFilterProvider
+    resourceFilterProvider,
+    awsClientProvider
   );
   vscode.window.createTreeView("amplify-backend-explorer", {
     treeDataProvider: amplifyBackendTreeDataProvider,
@@ -46,7 +49,10 @@ export function activate(context: vscode.ExtensionContext) {
     })
   );
 
-  const secretsTreeDataProvider = new SecretsTreeDataProvider(rootPath || "");
+  const secretsTreeDataProvider = new SecretsTreeDataProvider(
+    rootPath || "",
+    awsClientProvider
+  );
   vscode.window.createTreeView("amplify-backend-secrets-explorer", {
     treeDataProvider: secretsTreeDataProvider,
   });

--- a/src/project/amplify-project-impl.test.ts
+++ b/src/project/amplify-project-impl.test.ts
@@ -2,6 +2,8 @@ import { test, describe } from "mocha";
 import assert from "node:assert";
 import { AmplifyProjectImpl } from "./amplify-project-impl";
 import path from "node:path";
+import { mockClient } from 'aws-sdk-client-mock';
+import { CloudFormationClient, DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 
 describe("amplify-project-impl", () => {
   test("getStackName returns stack name", () => {
@@ -10,7 +12,8 @@ describe("amplify-project-impl", () => {
       "amplify-project-impl.test.fixtures",
       "app"
     );
-    const project = new AmplifyProjectImpl(projectPath);
+    const cloudFormationClientMock = mockClient(CloudFormationClient);
+    const project = new AmplifyProjectImpl(projectPath, cloudFormationClientMock as unknown as CloudFormationClient);
     assert.equal(
       project.getStackName(),
       "amplify-amplifyvitereacttemplate-fossamagna-sandbox-a8f5c46cb7"
@@ -23,7 +26,8 @@ describe("amplify-project-impl", () => {
       "amplify-project-impl.test.fixtures",
       "noapp"
     );
-    const project = new AmplifyProjectImpl(projectPath);
+    const cloudFormationClientMock = mockClient(CloudFormationClient);
+    const project = new AmplifyProjectImpl(projectPath, cloudFormationClientMock as unknown as CloudFormationClient);
     assert.equal(project.getStackName(), undefined);
   });
 
@@ -33,7 +37,8 @@ describe("amplify-project-impl", () => {
       "amplify-project-impl.test.fixtures",
       "app"
     );
-    const project = new AmplifyProjectImpl(projectPath);
+    const cloudFormationClientMock = mockClient(CloudFormationClient);
+    const project = new AmplifyProjectImpl(projectPath, cloudFormationClientMock as unknown as CloudFormationClient);
     assert.deepStrictEqual(project.getBackendIdentifier(), {
       namespace: "amplifyvitereacttemplate",
       name: "fossamagna",
@@ -48,7 +53,58 @@ describe("amplify-project-impl", () => {
       "amplify-project-impl.test.fixtures",
       "noapp"
     );
-    const project = new AmplifyProjectImpl(projectPath);
+    const cloudFormationClientMock = mockClient(CloudFormationClient);
+    const project = new AmplifyProjectImpl(projectPath, cloudFormationClientMock as unknown as CloudFormationClient);
     assert.equal(project.getBackendIdentifier(), undefined);
+  });
+
+  test("getStackArn returns stack ARN", async () => {
+    const projectPath = path.join(
+      __dirname,
+      "amplify-project-impl.test.fixtures",
+      "app"
+    );
+    const cloudFormationClientMock = mockClient(CloudFormationClient);
+    const expectedStackArn = "arn:aws:cloudformation:us-east-1:123456789012:stack/amplify-amplifyvitereacttemplate-fossamagna-sandbox-a8f5c46cb7/12345678-1234-1234-1234-123456789012";
+    cloudFormationClientMock.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackName: "amplify-amplifyvitereacttemplate-fossamagna-sandbox-a8f5c46cb7",
+          StackId: expectedStackArn,
+          CreationTime: new Date(),
+          StackStatus: "CREATE_COMPLETE",
+        },
+      ],
+    });
+    const project = new AmplifyProjectImpl(projectPath, cloudFormationClientMock as unknown as CloudFormationClient);
+    const stackArn = await project.getStackArn();
+    assert.equal(stackArn, expectedStackArn);
+  });
+
+  test("getStackArn returns undefined when stack is not found", async () => {
+    const projectPath = path.join(
+      __dirname,
+      "amplify-project-impl.test.fixtures",
+      "app"
+    );
+    const cloudFormationClientMock = mockClient(CloudFormationClient);
+    cloudFormationClientMock.on(DescribeStacksCommand).resolves({
+      Stacks: [],
+    });
+    const project = new AmplifyProjectImpl(projectPath, cloudFormationClientMock as unknown as CloudFormationClient);
+    const stackArn = await project.getStackArn();
+    assert.equal(stackArn, undefined);
+  });
+
+  test("getStackArn returns undefined when no exists manifest.json", async () => {
+    const projectPath = path.join(
+      __dirname,
+      "amplify-project-impl.test.fixtures",
+      "noapp"
+    );
+    const cloudFormationClientMock = mockClient(CloudFormationClient);
+    const project = new AmplifyProjectImpl(projectPath, cloudFormationClientMock as unknown as CloudFormationClient);
+    const stackArn = await project.getStackArn();
+    assert.equal(stackArn, undefined);
   });
 });

--- a/src/project/index.ts
+++ b/src/project/index.ts
@@ -1,10 +1,12 @@
 import type { AmplifyProject } from "./types";
 import { AmplifyProjectImpl } from "./amplify-project-impl";
+import { CloudFormationClient } from "@aws-sdk/client-cloudformation";
 
 export { AmplifyProject } from "./types";
 
 export const getAmplifyProject = (
-  amplifyProjectPath: string
+  amplifyProjectPath: string,
+  client: CloudFormationClient
 ): AmplifyProject => {
-  return new AmplifyProjectImpl(amplifyProjectPath);
+  return new AmplifyProjectImpl(amplifyProjectPath, client);
 };

--- a/src/project/types.ts
+++ b/src/project/types.ts
@@ -3,4 +3,5 @@ import type { BackendIdentifier } from "@aws-amplify/plugin-types";
 export interface AmplifyProject {
   getStackName(): string | undefined;
   getBackendIdentifier(): BackendIdentifier | undefined;
+  getStackArn(): Promise<string | undefined>;
 }


### PR DESCRIPTION
- Added aws-sdk-client-mock for testing AWS SDK interactions.
- Created AWSClientProvider to manage CloudFormationClient instantiation.
- Updated AmplifyBackendTreeDataProvider to use AWSClientProvider for CloudFormation operations.
- Modified AmplifyProjectImpl to include getStackArn method for retrieving stack ARN.
- Enhanced tests for AmplifyProjectImpl to validate stack ARN retrieval and handling of edge cases.
- Refactored SecretsTreeDataProvider to utilize AWSClientProvider for project detection.
- Updated package.json to include aws-sdk-client-mock dependency.